### PR TITLE
fix color theme name for vscode

### DIFF
--- a/vscode.json
+++ b/vscode.json
@@ -1,4 +1,4 @@
 {
-  "name": "Modern Purple Theme",
+  "name": "Modern Purple Theme Dark",
   "extension": "nataliefruitema.modern-purple-theme"
 }


### PR DESCRIPTION
Hi, I'm having trouble getting it to work properly in VS-Code. This is because Void tries to set the theme name to "Modern Purple Theme," but the theme has two versions: Dark and Light.

I'm submitting a pull request to fix the bug, setting the full theme name to "Modern Purple Theme Dark" as the default.